### PR TITLE
follow the location header if one is returned from the bsd api

### DIFF
--- a/src/Blue/Tools/Api/Client.php
+++ b/src/Blue/Tools/Api/Client.php
@@ -167,12 +167,9 @@ class Client
 
             while ($attempts > 0) {
 
-                $url = $this->baseUrl . "get_deferred_results";
-                $query = ['deferred_id' => $key];
-
                 /** @var ResponseInterface $deferredResponse */
                 $deferredResponse = $this->guzzleClient->get(
-                    $url,
+                    $this->baseUrl . "get_deferred_results",
                     [
                         'auth' => [
                             $this->id,
@@ -180,7 +177,7 @@ class Client
                             self::$AUTH_TYPE
                         ],
                         'future' => false,
-                        'query' => $query
+                        'query' => ['deferred_id' => $key]
                     ]
                 );
 

--- a/src/Blue/Tools/Api/Client.php
+++ b/src/Blue/Tools/Api/Client.php
@@ -156,17 +156,19 @@ class Client
 
             $attempts = $this->deferredResultMaxAttempts;
 
-            $locationHeader = $response->getHeader('location');
+            /**
+             * The mailer/send_triggered_email api method is a non-standard
+             * deferred api call.  It returns a JSON body in the format of
+             * {'mailing_triggered_id': 'deferred-id'}
+             **/
+            if($jsonResponse = json_decode($key, true)){
+                $key = $jsonResponse['mailing_triggered_id'];
+            }
 
             while ($attempts > 0) {
 
-                if($locationHeader) {
-                    $url = $this->baseUrl . ltrim($locationHeader,'/');
-                    $query = json_decode($key, true);
-                } else{
-                    $url = $this->baseUrl . "get_deferred_results";
-                    $query = ['deferred_id' => $key];
-                }
+                $url = $this->baseUrl . "get_deferred_results";
+                $query = ['deferred_id' => $key];
 
                 /** @var ResponseInterface $deferredResponse */
                 $deferredResponse = $this->guzzleClient->get(

--- a/src/Blue/Tools/Api/Client.php
+++ b/src/Blue/Tools/Api/Client.php
@@ -156,10 +156,21 @@ class Client
 
             $attempts = $this->deferredResultMaxAttempts;
 
+            $locationHeader = $response->getHeader('location');
+
             while ($attempts > 0) {
+
+                if($locationHeader) {
+                    $url = $this->baseUrl . ltrim($locationHeader,'/');
+                    $query = json_decode($key, true);
+                } else{
+                    $url = $this->baseUrl . "get_deferred_results";
+                    $query = ['deferred_id' => $key];
+                }
+
                 /** @var ResponseInterface $deferredResponse */
                 $deferredResponse = $this->guzzleClient->get(
-                    $this->baseUrl . "get_deferred_results",
+                    $url,
                     [
                         'auth' => [
                             $this->id,
@@ -167,9 +178,7 @@ class Client
                             self::$AUTH_TYPE
                         ],
                         'future' => false,
-                        'query' => [
-                            'deferred_id' => $key
-                        ]
+                        'query' => $query
                     ]
                 );
 


### PR DESCRIPTION
The send_triggered_email method returns a location header that should be followed to get the results of the email send.