### PR TITLE
Upgrading to guzzlehttp 6.3 and set the default timezone if it's not set

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,13 @@ $client->setDeferredResultInterval(30);
 $client->setDeferredResultMaxAttempts(10);
 ```
 
+The client polling for deferred calls can also be disabled.  When disabled, the deferred ID will be returned:
+
+```
+// Disable polling for the results and return the deferred ID
+$client->setProcessDeferredResults(false);
+```
+
 Installation
 ------------
 

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "license": "Apache-2.0",
   "require": {
     "php": ">=5.6",
-    "guzzlehttp/guzzle": "~6.0",
+    "guzzlehttp/guzzle": "~6.3",
     "nesbot/carbon": "~1.3",
     "psr/log": "~1.0"
   },

--- a/src/Blue/Tools/Api/Client.php
+++ b/src/Blue/Tools/Api/Client.php
@@ -40,6 +40,9 @@ class Client
     // Configuration
     //--------------------
 
+    /** @var bool */
+    protected $processDeferredResults = true;
+
     /** @var int */
     private $deferredResultMaxAttempts = 20;
 
@@ -151,7 +154,7 @@ class Client
     {
 
         // An HTTP status of 202 indicates that this request was deferred
-        if ($response->getStatusCode() == 202) {
+        if ($response->getStatusCode() == 202 && $this->processDeferredResults) {
             $key = $response->getBody()->getContents();
 
             $attempts = $this->deferredResultMaxAttempts;
@@ -199,6 +202,14 @@ class Client
     public function setDeferredResultInterval($deferredResultInterval)
     {
         $this->deferredResultInterval = $deferredResultInterval;
+    }
+
+    /**
+     * @param bool $processDeferredResults
+     */
+    public function setProcessDeferredResults($processDeferredResults)
+    {
+        $this->processDeferredResults = $processDeferredResults;
     }
 
     /**

--- a/src/Blue/Tools/Api/SigningHandler.php
+++ b/src/Blue/Tools/Api/SigningHandler.php
@@ -46,6 +46,11 @@ class SigningHandler
          * Add timestamp to the query
          */
         if (!isset($query['api_ts'])) {
+
+            if(empty(ini_get('date.timezone'))){
+                date_default_timezone_set('UTC');
+            }
+
             $now = Carbon::now();
             $query['api_ts'] = $now->getTimestamp();
         }

--- a/src/Blue/Tools/Api/SigningHandler.php
+++ b/src/Blue/Tools/Api/SigningHandler.php
@@ -46,11 +46,6 @@ class SigningHandler
          * Add timestamp to the query
          */
         if (!isset($query['api_ts'])) {
-
-            if(empty(ini_get('date.timezone'))){
-                date_default_timezone_set('UTC');
-            }
-
             $now = Carbon::now();
             $query['api_ts'] = $now->getTimestamp();
         }


### PR DESCRIPTION
- Upgrades guzzlehttp to 6.3
- Set the default timezone to UTC if date.timezone is not set in php.ini (Carbon throws a warning if the default timezone is not set)