### PR TITLE
The body, form_params, and multipart request options are all mutually exclusive, so set them only if they are passed in.  Also implemented multipart for file uploads

### DIFF
--- a/src/Blue/Tools/Api/Client.php
+++ b/src/Blue/Tools/Api/Client.php
@@ -127,21 +127,32 @@ class Client
      *
      * @param $apiPath
      * @param array  $queryParams
-     * @param string $data
-     * @param array $formParams
+     * @param string $body
+     * @param array  $formParams
+     * @param array  $multipart
      *
      * @return ResponseInterface
      */
-    public function post($apiPath, $queryParams = [], $data = '', $formParams = [])
+    public function post($apiPath, $queryParams = [], $body = '', $formParams = [], $multipart = [])
     {
+
+        $requestOptions['query'] = $queryParams;
+
+        if($body){
+            $requestOptions['body'] = $body;
+        }
+
+        if($formParams){
+            $requestOptions['form_params'] = $formParams;
+        }
+
+        if($multipart){
+            $requestOptions['multipart'] = $multipart;
+        }
+
         $response = $this->guzzleClient->post(
             $this->baseUrl.$apiPath,
-            [
-                'query'  => $queryParams,
-                'body'   => $data,
-                'future' => false,
-                'form_params' => $formParams
-            ]
+            $requestOptions
         );
 
         return $this->resolve($response);


### PR DESCRIPTION
This fixes a few issues related to using the newer version of guzzlehttp.