### PR TITLE
Update BSD Library to handle Triggered Mailing Appropriately

### DIFF
--- a/src/Blue/Tools/Api/Client.php
+++ b/src/Blue/Tools/Api/Client.php
@@ -183,8 +183,8 @@ class Client
                 $key = $content;
             }
             else if(isset($res->mailing_triggered_id)) {
-                // There is no need to check the deferred result for triggered mailing.
-                // Once the initial API is successful, we assume that the triggered mailing will be sent properly.
+                // The send_triggered_email API uses 202 to indicate something other than a traditional deferred result.
+                // Use get_triggered_send to verify the status of a triggered email.
                 return $response;
             }
             else {

--- a/src/Blue/Tools/Api/Client.php
+++ b/src/Blue/Tools/Api/Client.php
@@ -177,7 +177,19 @@ class Client
         // An HTTP status of 202 indicates that this request was deferred
         if ($response->getStatusCode() == 202) {
 
-            $key = $response->getBody()->getContents();
+            $content = $response->getBody()->getContents();
+            $res = json_decode($content);
+            if (json_last_error() != JSON_ERROR_NONE) {
+                $key = $content;
+            }
+            else if(isset($res->mailing_triggered_id)) {
+                // There is no need to check the deferred result for triggered mailing.
+                // Once the initial API is successful, we assume that the triggered mailing will be sent properly.
+                return $response;
+            }
+            else {
+                $key = $content;
+            }
 
             $attempts = $this->deferredResultMaxAttempts;
 


### PR DESCRIPTION
The triggered mailing API does not follow the standard deferred result  processing. We consider the api for triggered mailing is succesful when the initial call returns 202.